### PR TITLE
Fix #connection for mongoid5

### DIFF
--- a/lib/mongoid_rails_migrations/active_record_ext/migrations.rb
+++ b/lib/mongoid_rails_migrations/active_record_ext/migrations.rb
@@ -144,7 +144,11 @@ module Mongoid #:nodoc
 
       def connection
         # ActiveRecord::Base.connection
-        ::Mongoid.default_session
+        if ::Mongoid::VERSION < '5.0.0'
+          ::Mongoid.default_session
+        else
+          ::Mongoid.default_client
+        end
       end
 
       def method_missing(method, *arguments, &block)


### PR DESCRIPTION
The new ruby mongo driver uses 'client' speak
